### PR TITLE
DataSourceCache implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         gradleVersion = '4.4.1'
         gradleVersionsPluginVersion = '0.17.0'
         javaVersion = JavaVersion.VERSION_1_7
-        kotlinVersion = '1.2.21'
+        kotlinVersion = '1.2.30'
         kotlinxCoroutinesVersion = '0.21.2'
         kotlinxCollectionsImmutableVersion = '0.1'
         arrowVersion = '0.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         gradleVersion = '4.4.1'
         gradleVersionsPluginVersion = '0.17.0'
         javaVersion = JavaVersion.VERSION_1_7
-        kotlinVersion = '1.2.20'
+        kotlinVersion = '1.2.21'
         kotlinxCoroutinesVersion = '0.21.2'
         kotlinxCollectionsImmutableVersion = '0.1'
         arrowVersion = '0.6.0'

--- a/kollect-core/src/main/kotlin/kollect/Cache.kt
+++ b/kollect-core/src/main/kotlin/kollect/Cache.kt
@@ -29,8 +29,6 @@ interface DataSourceCache {
  */
 data class InMemoryCache(val state: Map<DataSourceIdentity, Any?>) : DataSourceCache {
 
-    constructor(vararg a: Tuple2<DataSourceIdentity, Any?>): this(toMap(*a))
-
     override fun <A> get(k: DataSourceIdentity): Option<A> =
         Option.fromNullable(state[k] as A?)
 
@@ -40,8 +38,8 @@ data class InMemoryCache(val state: Map<DataSourceIdentity, Any?>) : DataSourceC
     companion object {
         fun empty(): InMemoryCache = InMemoryCache(emptyMap())
 
-        fun toMap(vararg results: Tuple2<DataSourceIdentity, Any?>):  Map<DataSourceIdentity, Any?> =
-            results.fold(emptyMap(), { map, tuple2 -> map.plus(Pair(tuple2.a, tuple2.b))})
+        operator fun invoke(vararg results: Tuple2<DataSourceIdentity, Any?>): InMemoryCache =
+            InMemoryCache(results.fold(emptyMap(), { map, tuple2 -> map.plus(Pair(tuple2.a, tuple2.b)) }))
     }
 
 }

--- a/kollect-core/src/main/kotlin/kollect/Cache.kt
+++ b/kollect-core/src/main/kotlin/kollect/Cache.kt
@@ -29,8 +29,10 @@ interface DataSourceCache {
  */
 data class InMemoryCache(val state: Map<DataSourceIdentity, Any?>) : DataSourceCache {
 
+    constructor(vararg a: Tuple2<DataSourceIdentity, Any?>): this(toMap(*a))
+
     override fun <A> get(k: DataSourceIdentity): Option<A> =
-            Option.fromNullable(state[k] as A?)
+        Option.fromNullable(state[k] as A?)
 
     override fun <A> update(k: DataSourceIdentity, v: A): DataSourceCache =
         copy(state = state.plus(Pair(k, v)))
@@ -38,14 +40,8 @@ data class InMemoryCache(val state: Map<DataSourceIdentity, Any?>) : DataSourceC
     companion object {
         fun empty(): InMemoryCache = InMemoryCache(emptyMap())
 
-        fun apply(vararg results: Tuple2<DataSourceIdentity, Any?>): InMemoryCache =
-                InMemoryCache(results.fold(emptyMap(), { map, tuple2 -> map.plus(Pair(tuple2.a, tuple2.b))}))
+        fun toMap(vararg results: Tuple2<DataSourceIdentity, Any?>):  Map<DataSourceIdentity, Any?> =
+            results.fold(emptyMap(), { map, tuple2 -> map.plus(Pair(tuple2.a, tuple2.b))})
     }
-
-//    fun empty(): InMemoryCache =
-//            InMemoryCache(emptyMap())
-//
-//    fun combine(a: InMemoryCache, b: InMemoryCache): InMemoryCache =
-//            InMemoryCache(a.state.plus(b.state))
 
 }

--- a/kollect-core/src/main/kotlin/kollect/Cache.kt
+++ b/kollect-core/src/main/kotlin/kollect/Cache.kt
@@ -1,0 +1,51 @@
+package kollect
+
+import arrow.core.Option
+import arrow.core.Tuple2
+
+/**
+ * A `Cache` interface so the users of the library can provide their own cache.
+ */
+interface DataSourceCache {
+
+    fun <A> update(k: DataSourceIdentity, v: A): DataSourceCache
+
+    fun <A> get(k: DataSourceIdentity): Option<A>
+
+    fun <I : Any, A> getWithDS(ds: DataSource<I, A>): (I) -> Option<A> = { id -> get(ds.identity(id)) }
+
+    fun <I : Any, A> cacheResults(results: Map<I, A>, ds: DataSource<I, A>): DataSourceCache {
+        val op: (DataSourceCache, Map.Entry<I, A>) -> DataSourceCache = { dsc, e ->
+            dsc.update(ds.identity(e.key), e.value)
+        }
+        return results.entries.fold(this, op)
+    }
+
+    fun <A> contains(k: DataSourceIdentity): Boolean = get<A>(k).isDefined()
+}
+
+/**
+ * A cache that stores its elements in memory.
+ */
+data class InMemoryCache(val state: Map<DataSourceIdentity, Any?>) : DataSourceCache {
+
+    override fun <A> get(k: DataSourceIdentity): Option<A> =
+            Option.fromNullable(state[k] as A?)
+
+    override fun <A> update(k: DataSourceIdentity, v: A): DataSourceCache =
+        copy(state = state.plus(Pair(k, v)))
+
+    companion object {
+        fun empty(): InMemoryCache = InMemoryCache(emptyMap())
+
+        fun apply(vararg results: Tuple2<DataSourceIdentity, Any?>): InMemoryCache =
+                InMemoryCache(results.fold(emptyMap(), { map, tuple2 -> map.plus(Pair(tuple2.a, tuple2.b))}))
+    }
+
+//    fun empty(): InMemoryCache =
+//            InMemoryCache(emptyMap())
+//
+//    fun combine(a: InMemoryCache, b: InMemoryCache): InMemoryCache =
+//            InMemoryCache(a.state.plus(b.state))
+
+}

--- a/kollect-core/src/main/kotlin/kollect/arrow/instances/instances.kt
+++ b/kollect-core/src/main/kotlin/kollect/arrow/instances/instances.kt
@@ -1,0 +1,14 @@
+package kollect.arrow.instances
+
+import arrow.instance
+import arrow.typeclasses.Monoid
+import kollect.InMemoryCache
+
+@instance(InMemoryCache::class)
+interface InMemoryCacheMonoidInstance: Monoid<InMemoryCache> {
+
+    override fun empty(): InMemoryCache = InMemoryCache.empty()
+
+    override fun combine(a: InMemoryCache, b: InMemoryCache): InMemoryCache =
+        InMemoryCache(a.state.plus(b.state))
+}

--- a/kollect-core/src/main/kotlin/kollect/arrow/instances/instances.kt
+++ b/kollect-core/src/main/kotlin/kollect/arrow/instances/instances.kt
@@ -2,10 +2,11 @@ package kollect.arrow.instances
 
 import arrow.instance
 import arrow.typeclasses.Monoid
+import arrow.typeclasses.Semigroup
 import kollect.InMemoryCache
 
 @instance(InMemoryCache::class)
-interface InMemoryCacheMonoidInstance: Monoid<InMemoryCache> {
+interface InMemoryCacheMonoidInstance: Semigroup<InMemoryCache>, Monoid<InMemoryCache> {
 
     override fun empty(): InMemoryCache = InMemoryCache.empty()
 

--- a/kollect-core/src/test/kotlin/kollect/InMemoryCacheTest.kt
+++ b/kollect-core/src/test/kotlin/kollect/InMemoryCacheTest.kt
@@ -1,0 +1,40 @@
+package kollect
+
+import arrow.core.Tuple2
+import arrow.test.UnitSpec
+import arrow.test.laws.MonoidLaws
+import arrow.test.laws.SemigroupLaws
+import arrow.typeclasses.*
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.matchers.shouldNotBe
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class InMemoryCacheTest : UnitSpec() {
+
+    val EQ: Eq<InMemoryCache> = object : Eq<InMemoryCache> {
+        override fun eqv(a: InMemoryCache, b: InMemoryCache): Boolean = a.state == b.state
+    }
+
+    private fun dsCache(value: Int): InMemoryCache = InMemoryCache(Tuple2(Tuple2("ds", "key"), value))
+
+    init {
+
+        "instances can be resolved implicitly" {
+            monoid<InMemoryCache>() shouldNotBe null
+        }
+
+
+        testLaws(
+                MonoidLaws.laws(InMemoryCache.monoid(), dsCache(1), EQ),
+                SemigroupLaws.laws(InMemoryCache.monoid(),
+                        dsCache(1),
+                        dsCache(2),
+                        dsCache(3),
+                        EQ)
+        )
+
+    }
+
+
+}


### PR DESCRIPTION
This adds the `DataSourceCache` implementation.

I've added the `Monoid` instance at [`src/main/kotlin/kollect/arrow/instances/instances.kt`](https://github.com/47deg/kollect/pull/1/files#diff-9cb9e73c201e2a265f42412a1775e7ea). Please, let me know if it should be in another place.