### PR TITLE
Upgrade Kotlin and Arrow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,10 @@ buildscript {
         gradleVersion = '4.4.1'
         gradleVersionsPluginVersion = '0.17.0'
         javaVersion = JavaVersion.VERSION_1_7
-        kotlinVersion = '1.2.30'
+        kotlinVersion = '1.2.61'
         kotlinxCoroutinesVersion = '0.21.2'
         kotlinxCollectionsImmutableVersion = '0.1'
-        arrowVersion = '0.6.2-SNAPSHOT'
+        arrowVersion = '0.7.3'
     }
 
     repositories {

--- a/infographic/arrow-infographic.txt
+++ b/infographic/arrow-infographic.txt
@@ -1,0 +1,15 @@
+#.instances: fill=#B9F6CA visual=class italic bold dashed
+#.typeclasses: fill=#64B5F6 visual=database bold
+#arrowSize: 1
+#bendSize: 0.3
+#fill: #64B5F6
+#font: Menlo
+#fontSize: 10
+#lineWidth: 2
+#padding: 8
+#zoom: 1
+[<typeclasses>Functor]<-[<typeclasses>Applicative]
+[<typeclasses>Semigroup]<-[<typeclasses>Monoid]
+[<typeclasses>Applicative]<-[<instances>Applicative Instances|KollectApplicativeInstance|KollectOpApplicativeInstance|QueryApplicativeInstance]
+[<typeclasses>Monoid]<-[<instances>Monoid Instances|InMemoryCacheMonoidInstance]
+[<typeclasses>Semigroup]<-[<instances>Semigroup Instances|InMemoryCacheMonoidInstance]

--- a/kollect-core/build.gradle
+++ b/kollect-core/build.gradle
@@ -1,7 +1,11 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile "io.arrow-kt:arrow-free:$arrowVersion"
     compile "io.arrow-kt:arrow-effects:$arrowVersion"
+    compile "io.arrow-kt:arrow-instances-core:$arrowVersion"
+    compile "io.arrow-kt:arrow-instances-data:$arrowVersion"
+    compile "io.arrow-kt:arrow-typeclasses:$arrowVersion"
+    compile "io.arrow-kt:arrow-data:$arrowVersion"
 
     kapt "io.arrow-kt:arrow-annotations-processor:$arrowVersion"
 

--- a/kollect-core/src/main/kotlin/kollect/KollectMonadError.kt
+++ b/kollect-core/src/main/kotlin/kollect/KollectMonadError.kt
@@ -1,30 +1,9 @@
 package kollect
 
 import arrow.Kind
-import arrow.TC
-import arrow.core.Either
-import arrow.typeclass
 import arrow.typeclasses.MonadError
 
-@typeclass(syntax = false)
-interface KollectMonadError<F> : MonadError<F, KollectError>, TC {
-
-    fun ME(): MonadError<F, Throwable>
+interface KollectMonadError<F> : MonadError<F, Throwable> {
 
     fun <A> runQuery(q: Query<A>): Kind<F, A>
-
-    override fun <A> pure(a: A): Kind<F, A> =
-            ME().pure(a)
-
-    override fun <A, B> flatMap(fa: Kind<F, A>, f: (A) -> Kind<F, B>): Kind<F, B> =
-            ME().flatMap(fa, f)
-
-    override fun <A, B> tailRecM(a: A, f: (A) -> Kind<F, Either<A, B>>): Kind<F, B> =
-            ME().tailRecM(a, f)
-
-    override fun <A> handleErrorWith(fa: Kind<F, A>, f: (KollectError) -> Kind<F, A>): Kind<F, A> =
-            ME().handleErrorWith(fa, { e -> f(e as KollectError) })
-
-    override fun <A> raiseError(e: KollectError): Kind<F, A> =
-            ME().raiseError(e)
 }

--- a/kollect-core/src/main/kotlin/kollect/Query.kt
+++ b/kollect-core/src/main/kotlin/kollect/Query.kt
@@ -1,10 +1,7 @@
 package kollect
 
-import arrow.core.*
-import arrow.deriving
+import arrow.core.Eval
 import arrow.higherkind
-import arrow.typeclasses.Applicative
-import arrow.typeclasses.Functor
 import java.time.Duration
 
 val Infinite: Duration = Duration.ofDays(Long.MAX_VALUE)
@@ -13,17 +10,16 @@ typealias QueryCallback<A> = (A) -> Unit
 typealias QueryErrorback = (Throwable) -> Unit
 
 @higherkind
-@deriving(Functor::class, Applicative::class)
 sealed class Query<A> : QueryOf<A> {
 
     fun <B> ap(ff: QueryOf<(A) -> B>): Query<B> =
         Ap(this, ff.fix())
 
-    fun <B> map(f: (A) -> B): Query<B> = ap(pure(f))
+    fun <B> map(f: (A) -> B): Query<B> = ap(just(f))
 
     companion object {
 
-        fun <A> pure(x: A): Query<A> = Sync(Eval.now(x))
+        fun <A> just(x: A): Query<A> = Sync(Eval.now(x))
 
         fun <A> eval(e: Eval<A>): Query<A> = Sync(e)
 
@@ -40,7 +36,7 @@ data class Sync<A>(val action: Eval<A>) : Query<A>()
 
 /** A query that can only be satisfied asynchronously. **/
 data class Async<A>(
-        val action: (QueryCallback<A>, QueryErrorback) -> Unit,
-        val timeout: Duration) : Query<A>()
+    val action: (QueryCallback<A>, QueryErrorback) -> Unit,
+    val timeout: Duration) : Query<A>()
 
 data class Ap<A, B>(val fa: Query<A>, val ff: Query<(A) -> B>) : Query<B>()

--- a/kollect-core/src/main/kotlin/kollect/arrow/extensions/extensions.kt
+++ b/kollect-core/src/main/kotlin/kollect/arrow/extensions/extensions.kt
@@ -1,11 +1,9 @@
 package kollect.arrow.extensions
 
-import arrow.*
-import arrow.core.*
-import arrow.typeclasses.*
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.core.toT
+import arrow.typeclasses.Functor
 
 fun <F, A, B> Functor<F>.tupleLeft(fa: Kind<F, A>, b: B): Kind<F, Tuple2<B, A>> =
-        map(fa, { a -> b toT a })
-
-inline fun <reified F, A, B> Kind<F, A>.tupleLeft(b: B, FF: Functor<F> = functor()): Kind<F, Tuple2<B, A>> =
-        FF.tupleLeft(this, b)
+    fa.map { a -> b toT a }

--- a/kollect-core/src/main/kotlin/kollect/arrow/instances/core/instances.kt
+++ b/kollect-core/src/main/kotlin/kollect/arrow/instances/core/instances.kt
@@ -1,16 +1,19 @@
 package arrow.core
 
 import arrow.Kind
-import arrow.typeclasses.MonadError
+import arrow.instance
+import arrow.instances.TryMonadInstance
 import kollect.KollectMonadError
 import kollect.Query
 
-object TryKollectMonadErrorInstance : KollectMonadError<ForTry> {
-    override fun ME(): MonadError<ForTry, Throwable> = Try.monadError()
+@instance(Try::class)
+interface TryKollectMonadErrorInstance : TryMonadInstance, KollectMonadError<ForTry> {
+
+    override fun <A> raiseError(e: Throwable): Try<A> =
+        Failure(e)
+
+    override fun <A> Kind<ForTry, A>.handleErrorWith(f: (Throwable) -> Kind<ForTry, A>): Try<A> =
+        fix().recoverWith { f(it).fix() }
 
     override fun <A> runQuery(q: Query<A>): Kind<ForTry, A> = TODO()
-}
-
-object TryKollectMonadErrorInstanceImplicits {
-    fun instance(): TryKollectMonadErrorInstance = TryKollectMonadErrorInstance
 }

--- a/kollect-core/src/main/kotlin/kollect/arrow/instances/effects/instances.kt
+++ b/kollect-core/src/main/kotlin/kollect/arrow/instances/effects/instances.kt
@@ -1,16 +1,46 @@
 package arrow.effects
 
 import arrow.Kind
-import arrow.typeclasses.MonadError
+import arrow.core.Either
+import arrow.instance
+import arrow.typeclasses.Applicative
+import kollect.ForQuery
 import kollect.KollectMonadError
 import kollect.Query
+import kollect.fix
+import arrow.effects.handleErrorWith as ioHandleErrorWith
 
-object IOKollectMonadErrorInstance : KollectMonadError<ForIO> {
-    override fun ME(): MonadError<ForIO, Throwable> = IO.monadError()
+@instance(Query::class)
+interface QueryApplicativeInstance : Applicative<ForQuery> {
+    override fun <A> just(a: A): Query<A> = Query.just(a)
 
-    override fun <A> runQuery(q: Query<A>): Kind<ForIO, A> = TODO()
+    override fun <A, B> Kind<ForQuery, A>.ap(ff: Kind<ForQuery, (A) -> B>): Query<B> =
+        fix().ap(ff)
 }
 
-object IOKollectMonadErrorInstanceImplicits {
-    fun instance(): IOKollectMonadErrorInstance = IOKollectMonadErrorInstance
+@instance(IO::class)
+interface IOKollectMonadErrorInstance : KollectMonadError<ForIO> {
+
+    override fun <A> just(a: A): IO<A> =
+        IO.just(a)
+
+    override fun <A, B> Kind<ForIO, A>.flatMap(f: (A) -> Kind<ForIO, B>): IO<B> =
+        fix().flatMap(f)
+
+    override fun <A, B> Kind<ForIO, A>.map(f: (A) -> B): IO<B> =
+        fix().map(f)
+
+    override fun <A, B> tailRecM(a: A, f: kotlin.Function1<A, IOOf<arrow.core.Either<A, B>>>): IO<B> =
+        IO.tailRecM(a, f)
+
+    override fun <A> Kind<ForIO, A>.attempt(): IO<Either<Throwable, A>> =
+        fix().attempt()
+
+    override fun <A> Kind<ForIO, A>.handleErrorWith(f: (Throwable) -> Kind<ForIO, A>): IO<A> =
+        fix().ioHandleErrorWith(f)
+
+    override fun <A> raiseError(e: Throwable): IO<A> =
+        IO.raiseError(e)
+
+    override fun <A> runQuery(q: Query<A>): Kind<ForIO, A> = TODO()
 }

--- a/kollect-core/src/main/kotlin/kollect/arrow/instances/instances.kt
+++ b/kollect-core/src/main/kotlin/kollect/arrow/instances/instances.kt
@@ -10,6 +10,6 @@ interface InMemoryCacheMonoidInstance : Semigroup<InMemoryCache>, Monoid<InMemor
 
     override fun empty(): InMemoryCache = InMemoryCache.empty()
 
-    override fun combine(a: InMemoryCache, b: InMemoryCache): InMemoryCache =
-        InMemoryCache(a.state.plus(b.state))
+    override fun InMemoryCache.combine(b: InMemoryCache): InMemoryCache =
+        InMemoryCache(this.state.plus(b.state))
 }


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #9 

### :tophat: What is the goal?

* Update Kotlin to `1.2.61` to match Kotlin version used by lastest Arrow release.
* Update Arrow to `0.7.3`.

### 💻 How is it being implemented?

* Upgraded both versions.
* Adapter the whole project to use the lastest Arrow released syntax.

There's no intention on refactoring or redesigning this yet. That'll need to wait a bit more. This is mostly a middle step to start working on that when it's possible. And also for me to get to understand how `Kollect` works.

### 📱 How to Test

* No much to test yet. Better just take a look to what has been ported and report anything found that doesn't make much sense regarding what the library had implemented before these changes.