### PR TITLE
Add Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+### ⚠️ TEMPLATE ⚠️
+**Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your commited changes.**
+
+### :pushpin: References
+**Issues:**
+* Fixes #1
+
+### :tophat: What is the goal?
+
+* Here you would describe the PR goals. Just the stuff we need to implement for the fix / feature and a simple rationale.
+* It could contain many check points if needed. We have no restrictions at all on the content of each section itself.
+
+### 💻 How is it being implemented?
+
+Here we use to include all the relevant things implemented and also rationale, aclarations / disclaimers etc related to the approach you used.
+
+* Stuff implemented 1
+* Stuff implemented 2
+* Stuff implemented 3
+
+### 📱 How to Test
+
+Here we use to add the steps to manually test the PR. Here you have some sample checks:
+
+* Step 1
+* Step 2
+* Step 3

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Here we use to include all the relevant things implemented and also rationale, a
 
 ### 📱 How to Test
 
-Here we use to add the steps to manually test the PR. Here you have some sample checks:
+Here we use to add the steps to test the implemented changes. Here you have some sample checks:
 
 * Step 1
 * Step 2


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #11 

### :tophat: What is the goal?

* Add a Pull Request template for promoting detailed PR descriptions about the work done.

### 💻 How is it being implemented?

* Added template on the `.github` dir so GitHub automatically fetches and displays it for every newly opened PR after this one.